### PR TITLE
Mini test framework + patch UB NULL on utf8codepoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,191 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/c,c++,cmake,jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=c,c++,cmake,jetbrains+all
+
+### C ###
+# Prerequisites
+*.d
+
+# Object files
 *.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
 *.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+### C++ ###
+# Prerequisites
+
+# Compiled Object files
+*.slo
+
+# Precompiled Headers
+
+# Linker files
+
+# Debugger Files
+
+# Compiled Dynamic libraries
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+
+# Executables
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+# End of https://www.toptal.com/developers/gitignore/api/c,c++,cmake,jetbrains+all
+
 build/

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,0 +1,13 @@
+#ifndef UTF8_DECODER_TEST_H
+#define UTF8_DECODER_TEST_H
+
+#define BEGIN_TESTS int number_of_tests = 0; int passed_tests = 0; int t;
+#define END_TESTS printf("Passed %i/%i (failed %i)\n", passed_tests, number_of_tests, number_of_tests - passed_tests);
+
+#define REGISTER_TEST number_of_tests++
+#define RUN(e, r) t = (e == r); passed_tests += t
+#define PRINT(s) printf("test %s: %i\n", s, t);
+
+#define TEST(expected, real, message) REGISTER_TEST; RUN(expected, real); PRINT(message);
+
+#endif //UTF8_DECODER_TEST_H

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,13 +1,16 @@
 #ifndef UTF8_DECODER_TEST_H
 #define UTF8_DECODER_TEST_H
 
-#define BEGIN_TESTS int number_of_tests = 0; int passed_tests = 0; int t;
-#define END_TESTS printf("Passed %i/%i (failed %i)\n", passed_tests, number_of_tests, number_of_tests - passed_tests);
-
 #define REGISTER_TEST number_of_tests++
 #define RUN(e, r) t = (e == r); passed_tests += t
 #define PRINT(s) printf("test %s: %i\n", s, t);
 
-#define TEST(expected, real, message) REGISTER_TEST; RUN(expected, real); PRINT(message);
+#define PRINT_END printf("Passed %i/%i (failed %i)\n", passed_tests, number_of_tests, number_of_tests - passed_tests)
+#define RETURN_END return (number_of_tests - passed_tests > 0)
+
+#define TEST(expected, real, message) REGISTER_TEST; RUN(expected, real); PRINT(message)
+
+#define BEGIN_TESTS int number_of_tests = 0; int passed_tests = 0; int t;
+#define END_TESTS PRINT_END; RETURN_END;
 
 #endif //UTF8_DECODER_TEST_H

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 #include <stdio.h>
-#include <utf8_decoder.h>
+#include "../utf8_decoder.h"
 #include "test.h"
 
 int main()

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -21,12 +21,21 @@
 // THE SOFTWARE.
 
 #include <stdio.h>
-#include <stdint.h>
 #include <utf8_decoder.h>
 
-int main(void)
-{
-    utf8codepoint("A");
+int test_null_codepoint(int *nb) {
+    int test = utf8codepoint(NULL) == 0;
 
-    return 0;
+    *nb += test;
+    return test;
+}
+
+int main()
+{
+    int nb_tests = 1;
+    int nb_passed = 0;
+
+    printf("test null codepoint: %i\n", test_null_codepoint(&nb_passed));
+
+    return (nb_tests - nb_passed > 0);
 }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -22,20 +22,16 @@
 
 #include <stdio.h>
 #include <utf8_decoder.h>
-
-int test_null_codepoint(int *nb) {
-    int test = utf8codepoint(NULL) == 0;
-
-    *nb += test;
-    return test;
-}
+#include "test.h"
 
 int main()
 {
-    int nb_tests = 1;
-    int nb_passed = 0;
+    BEGIN_TESTS
 
-    printf("test null codepoint: %i\n", test_null_codepoint(&nb_passed));
+    TEST(0, utf8codepoint(NULL), "null codepoint")
+    TEST(65, utf8codepoint("A"), "codepoint A")
 
-    return (nb_tests - nb_passed > 0);
+    END_TESTS
+
+    return (number_of_tests - passed_tests > 0);
 }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -28,10 +28,8 @@ int main()
 {
     BEGIN_TESTS
 
-    TEST(0, utf8codepoint(NULL), "null codepoint")
-    TEST(65, utf8codepoint("A"), "codepoint A")
+    TEST(0, utf8codepoint(NULL), "null codepoint");
+    TEST(65, utf8codepoint("A"), "codepoint A");
 
     END_TESTS
-
-    return (number_of_tests - passed_tests > 0);
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -22,20 +22,16 @@
 
 #include <iostream>
 #include "../utf8_decoder.h"
-
-int test_null_codepoint(int& nb) {
-    int test = utf8codepoint(NULL) == 0;
-
-    nb += test;
-    return test;
-}
+#include "test.h"
 
 int main()
 {
-    int nb_tests = 1;
-    int nb_passed = 0;
+    BEGIN_TESTS
 
-    std::cout << "test null codepoint: " << test_null_codepoint(nb_passed) << "\n";
+    TEST(0, utf8codepoint(NULL), "null codepoint")
+    TEST(65, utf8codepoint("A"), "codepoint A")
 
-    return (nb_tests - nb_passed > 0);
+    END_TESTS
+
+    return (number_of_tests - passed_tests > 0);
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -20,11 +20,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <utf8_decoder.h>
+#include <iostream>
+#include "../utf8_decoder.h"
 
-int main(void)
+int test_null_codepoint(int& nb) {
+    int test = utf8codepoint(NULL) == 0;
+
+    nb += test;
+    return test;
+}
+
+int main()
 {
-    utf8codepoint(NULL);
+    int nb_tests = 1;
+    int nb_passed = 0;
 
-    return 0;
+    std::cout << "test null codepoint: " << test_null_codepoint(nb_passed) << "\n";
+
+    return (nb_tests - nb_passed > 0);
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -28,10 +28,8 @@ int main()
 {
     BEGIN_TESTS
 
-    TEST(0, utf8codepoint(NULL), "null codepoint")
-    TEST(65, utf8codepoint("A"), "codepoint A")
+    TEST(0, utf8codepoint(NULL), "null codepoint");
+    TEST(65, utf8codepoint("A"), "codepoint A");
 
     END_TESTS
-
-    return (number_of_tests - passed_tests > 0);
 }

--- a/utf8_decoder.h
+++ b/utf8_decoder.h
@@ -325,6 +325,8 @@ static short utf8valid(const char *str)
 {
     const char *s = str;
 
+    if (str == NULL) return UTF8_GOOD_CHAR;
+
     while(*s != END)
     {
         if(0xf0 == (0xf8 & *s))
@@ -408,6 +410,8 @@ static int32_t utf8codepoint(const char *str)
     const char *s = str;
 
     if(utf8valid(str))
+        if (str == NULL) return 0;
+
         while(*s != END)
         {
             if(0xf0 == (0xf8 & *s))


### PR DESCRIPTION
Added a simple yet powerful test header to allow for better and cleaner test writing.
Fixed segfault on the cpp tests upon giving `NULL` to `utf8codepoint`; now returns `0` as intended.